### PR TITLE
fix problems 

### DIFF
--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -21,10 +21,10 @@ table::
     ## soft::ctrl + u:: || scroll more lines up
     ## soft::h:: or soft::alt + left arrow:: || go back
     ## soft::l:: or soft::alt + right arrow:: || go forward
-    ## soft::G:: || go to bottom
+    ## soft::G:: || go to bottom 
     ## soft::g:: || go to top
     ## soft::shift + j:: or soft::ctrl + minus:: || zoom out
-    ## soft::shift + k:: or soft::ctrl + equal/plus: || zoom in
+    ## soft::shift + k:: or soft::ctrl + equal/plus:: || zoom in
     ## soft::/:: or soft::ctrl + f:: || search in page
     ## soft::F3:: || open Search page
     ## soft::F5:: || reload page

--- a/editors/sc-ide/core/util/overriding_action.hpp
+++ b/editors/sc-ide/core/util/overriding_action.hpp
@@ -48,9 +48,7 @@ public:
         if (event->key() >= Qt::Key_Shift && event->key() <= Qt::Key_Alt)
             return QKeySequence();
 
-        Qt::KeyboardModifiers modifiers = event->modifiers() & ~Qt::KeypadModifier;
-
-        return QKeySequence(modifiers | event->key());
+        return QKeySequence(event->modifiers() | event->key());
     }
 
 protected:

--- a/editors/sc-ide/core/util/overriding_action.hpp
+++ b/editors/sc-ide/core/util/overriding_action.hpp
@@ -50,7 +50,7 @@ public:
 
         Qt::KeyboardModifiers modifiers = event->modifiers() & ~Qt::KeypadModifier;
 
-        return QKeySequence(event->modifiers() | event->key());
+        return QKeySequence(modifiers | event->key());
     }
 
 protected:

--- a/editors/sc-ide/core/util/overriding_action.hpp
+++ b/editors/sc-ide/core/util/overriding_action.hpp
@@ -29,14 +29,14 @@ namespace ScIDE {
 
 class OverridingAction : public QAction {
 public:
-    OverridingAction(QObject* parent): QAction(parent) { setShortcutContext(Qt::WidgetWithChildrenShortcut); }
+    OverridingAction(QObject* parent): QAction(parent) { setShortcutContext(Qt::WindowShortcut); }
 
     OverridingAction(const QString& text, QObject* parent): QAction(text, parent) {
-        setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        setShortcutContext(Qt::WindowShortcut);
     }
 
     OverridingAction(const QIcon& icon, const QString& text, QObject* parent): QAction(icon, text, parent) {
-        setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        setShortcutContext(Qt::WindowShortcut);
     }
 
     void addToWidget(QWidget* widget) {

--- a/editors/sc-ide/core/util/overriding_action.hpp
+++ b/editors/sc-ide/core/util/overriding_action.hpp
@@ -29,14 +29,14 @@ namespace ScIDE {
 
 class OverridingAction : public QAction {
 public:
-    OverridingAction(QObject* parent): QAction(parent) { setShortcutContext(Qt::WindowShortcut); }
+    OverridingAction(QObject* parent): QAction(parent) { setShortcutContext(Qt::WidgetWithChildrenShortcut); }
 
     OverridingAction(const QString& text, QObject* parent): QAction(text, parent) {
-        setShortcutContext(Qt::WindowShortcut);
+        setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
 
     OverridingAction(const QIcon& icon, const QString& text, QObject* parent): QAction(icon, text, parent) {
-        setShortcutContext(Qt::WindowShortcut);
+        setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
 
     void addToWidget(QWidget* widget) {

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -63,6 +63,10 @@ using namespace QtCollider;
 #    ifdef Q_OS_WIN
 QAction* HelpBrowser::winCtrlRBlocker = nullptr;
 #    endif
+#    ifdef Q_OS_MAC
+QAction* HelpBrowser::macCmdPlusBlocker = nullptr;
+// QAction* HelpBrowser::macCmdEqualBlocker = nullptr;
+#    endif
 
 HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     QRect availableScreenRect = qApp->primaryScreen()->availableGeometry();
@@ -146,10 +150,6 @@ void HelpBrowser::onPageLoad() {
     static_cast<OverridingAction*>(mActions[Back])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Forward])->addToWidget(mWebView->focusProxy());
 
-    // mActions[ZoomIn]->setShortcutContext(Qt::WindowShortcut);
-    // mActions[ZoomOut]->setShortcutContext(Qt::WindowShortcut);
-    // mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
-
 #    ifdef Q_OS_WIN
     if (!winCtrlRBlocker) {
         winCtrlRBlocker = new OverridingAction(this);
@@ -157,6 +157,25 @@ void HelpBrowser::onPageLoad() {
         winCtrlRBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
     mWebView->focusProxy()->addAction(winCtrlRBlocker);
+#    endif
+
+#    ifdef Q_OS_MAC
+    if (!macCmdPlusBlocker) {
+        macCmdPlusBlocker = new OverridingAction(this);
+        // "Cmd++" 수신 시 주 편집창으로 가지 못하게 focusProxy 레벨에서 가로챔
+        macCmdPlusBlocker->setShortcut(QKeySequence("Cmd++"));
+        macCmdPlusBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        // 가로챈 뒤, HelpBrowser의 줌인 기능을 수행하도록 연결
+        connect(macCmdPlusBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
+    }
+    if (!macCmdEqualBlocker) {
+        macCmdEqualBlocker = new OverridingAction(this);
+        macCmdEqualBlocker->setShortcut(QKeySequence("Cmd+="));
+        macCmdEqualBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        connect(macCmdEqualBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
+    }
+    mWebView->focusProxy()->addAction(macCmdPlusBlocker);
+    mWebView->focusProxy()->addAction(macCmdEqualBlocker);
 #    endif
 }
 
@@ -233,10 +252,6 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
     mActions[ZoomIn]->setShortcuts(zoomInShortcuts);
     mActions[ZoomOut]->setShortcut(settings->shortcut("editor-shrink-font"));
     mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
-
-    // mActions[ZoomIn]->setShortcutContext(Qt::WindowShortcut);
-    // mActions[ZoomOut]->setShortcutContext(Qt::WindowShortcut);
-    // mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
 
     QList<QKeySequence> evalShortcuts;
     evalShortcuts.append(settings->shortcut("editor-eval-line"));

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -60,6 +60,10 @@ namespace ScIDE {
 
 using namespace QtCollider;
 
+#    ifdef Q_OS_WIN
+QAction* HelpBrowser::winCtrlRBlocker = nullptr;
+#    endif
+
 HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     QRect availableScreenRect = qApp->primaryScreen()->availableGeometry();
     mSizeHint = QSize(availableScreenRect.width() * 0.4, availableScreenRect.height() * 0.7);
@@ -82,10 +86,6 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     // On macOS, checkboxes unwantedly appear in the top left-hand corner.
     // See QTBUG-43366, 43070, and 42948. The workaround is to set style to fusion.
     mWebView->setStyle(QStyleFactory::create("Fusion"));
-#    endif
-
-#    ifdef Q_OS_WIN
-    QAction* HelpBrowser::winCtrlRBlocker = nullptr;
 #    endif
 
     mWebView->installEventFilter(this);

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -143,7 +143,6 @@ void HelpBrowser::onPageLoad() {
     // add these actions to weview's renderer, to capture shift+enter and possibly other swallowed shortcuts
     static_cast<OverridingAction*>(mActions[EvaluateRegion])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Evaluate])->addToWidget(mWebView->focusProxy());
-
     static_cast<OverridingAction*>(mActions[ZoomIn])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ZoomOut])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ResetZoom])->addToWidget(mWebView->focusProxy());
@@ -242,11 +241,12 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
     zoomInShortcuts.append(settings->shortcut("editor-enlarge-font"));
 
 #    ifdef Q_OS_MAC
-    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Equal)); // Cmd + =
-    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus)); // Cmd + + (keypad)
+    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Equal));
+    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus));
 #    else
-    zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal)); // Ctrl + =
-    zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Plus)); // Ctrl + + (keypad)
+    zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal));
+    zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Plus));
+    zoomInShortcuts.append(QKeySequence("Ctrl++"));
 #    endif
 
     mActions[ZoomIn]->setShortcuts(zoomInShortcuts);

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -144,7 +144,6 @@ void HelpBrowser::onPageLoad() {
     static_cast<OverridingAction*>(mActions[EvaluateRegion])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Evaluate])->addToWidget(mWebView->focusProxy());
 
-    // 이 오버라이딩 액션들이 focusProxy에 주입되면서 웹뷰 바닥에서부터 키를 낚아챕니다.
     static_cast<OverridingAction*>(mActions[ZoomIn])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ZoomOut])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ResetZoom])->addToWidget(mWebView->focusProxy());
@@ -152,10 +151,7 @@ void HelpBrowser::onPageLoad() {
     static_cast<OverridingAction*>(mActions[Back])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Forward])->addToWidget(mWebView->focusProxy());
 
-    // [맥OS 핵심 방어] focusProxy 내부에서 Zoom 액션들이 메인 메뉴바의 단축키를 이기도록
-    // WidgetWithChildrenShortcut 컨텍스트를 확실하게 재명시해 줍니다.
-#    ifdef Q_OS_MAC
-    mActions[ZoomIn]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    ifdef Q_OS_MAC mActions[ZoomIn]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mActions[ZoomOut]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mActions[ResetZoom]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 #    endif

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -169,16 +169,14 @@ void HelpBrowser::onPageLoad() {
 #    ifdef Q_OS_MAC
     if (!macCmdPlusBlocker) {
         macCmdPlusBlocker = new OverridingAction(this);
-        macCmdPlusBlocker->setShortcut(QKeySequence("Cmd++"));
-        macCmdPlusBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-
+        macCmdPlusBlocker->setShortcut(QKeySequence(Qt::META | Qt::Key_Plus));
+        macCmdPlusBlocker->setShortcutContext(Qt::WindowShortcut);
         connect(macCmdPlusBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
     }
     if (!macCmdEqualBlocker) {
         macCmdEqualBlocker = new OverridingAction(this);
-        macCmdEqualBlocker->setShortcut(QKeySequence("Cmd+="));
-        macCmdEqualBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-
+        macCmdEqualBlocker->setShortcut(QKeySequence(Qt::META | Qt::Key_Equal));
+        macCmdEqualBlocker->setShortcutContext(Qt::WindowShortcut);
         connect(macCmdEqualBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
     }
     mWebView->focusProxy()->addAction(macCmdPlusBlocker);

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -169,13 +169,13 @@ void HelpBrowser::onPageLoad() {
     if (!macCmdPlusBlocker) {
         macCmdPlusBlocker = new OverridingAction(this);
         macCmdPlusBlocker->setShortcut(QKeySequence(Qt::META | Qt::Key_Plus));
-        macCmdPlusBlocker->setShortcutContext(Qt::WindowShortcut);
+        macCmdPlusBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         connect(macCmdPlusBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
     }
     if (!macCmdEqualBlocker) {
         macCmdEqualBlocker = new OverridingAction(this);
         macCmdEqualBlocker->setShortcut(QKeySequence(Qt::META | Qt::Key_Equal));
-        macCmdEqualBlocker->setShortcutContext(Qt::WindowShortcut);
+        macCmdEqualBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         connect(macCmdEqualBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
     }
     mWebView->focusProxy()->addAction(macCmdPlusBlocker);

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -64,8 +64,8 @@ using namespace QtCollider;
 QAction* HelpBrowser::winCtrlRBlocker = nullptr;
 #    endif
 #    ifdef Q_OS_MAC
-QAction* HelpBrowser::macCmdPlusBlocker = nullptr;
-QAction* HelpBrowser::macCmdEqualBlocker = nullptr;
+QAction* HelpBrowser::macCmdPlusBlocker = nullptr; // does not work
+QAction* HelpBrowser::macCmdEqualBlocker = nullptr; // does not work
 #    endif
 
 HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
@@ -167,6 +167,25 @@ void HelpBrowser::onPageLoad() {
         winCtrlRBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
     mWebView->focusProxy()->addAction(winCtrlRBlocker);
+#    endif
+
+#    ifdef Q_OS_MAC
+    if (!macCmdPlusBlocker) {
+        macCmdPlusBlocker = new OverridingAction(this);
+        macCmdPlusBlocker->setShortcut(QKeySequence("Cmd++"));
+        macCmdPlusBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+
+        connect(macCmdPlusBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
+    }
+    if (!macCmdEqualBlocker) {
+        macCmdEqualBlocker = new OverridingAction(this);
+        macCmdEqualBlocker->setShortcut(QKeySequence("Cmd+="));
+        macCmdEqualBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+
+        connect(macCmdEqualBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
+    }
+    mWebView->focusProxy()->addAction(macCmdPlusBlocker);
+    mWebView->focusProxy()->addAction(macCmdEqualBlocker);
 #    endif
 }
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -84,6 +84,10 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     mWebView->setStyle(QStyleFactory::create("Fusion"));
 #    endif
 
+#    ifdef Q_OS_WIN
+    QAction* HelpBrowser::winCtrlRBlocker = nullptr;
+#    endif
+
     mWebView->installEventFilter(this);
 
     mLoadProgressIndicator = new LoadProgressIndicator;
@@ -147,7 +151,6 @@ void HelpBrowser::onPageLoad() {
     mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
 
 #    ifdef Q_OS_WIN
-    static QAction* winCtrlRBlocker = nullptr;
     if (!winCtrlRBlocker) {
         winCtrlRBlocker = new OverridingAction(this);
         winCtrlRBlocker->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -151,7 +151,8 @@ void HelpBrowser::onPageLoad() {
     static_cast<OverridingAction*>(mActions[Back])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Forward])->addToWidget(mWebView->focusProxy());
 
-    ifdef Q_OS_MAC mActions[ZoomIn]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+#    ifdef Q_OS_MAC
+    mActions[ZoomIn]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mActions[ZoomOut]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mActions[ResetZoom]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 #    endif

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -65,7 +65,7 @@ QAction* HelpBrowser::winCtrlRBlocker = nullptr;
 #    endif
 #    ifdef Q_OS_MAC
 QAction* HelpBrowser::macCmdPlusBlocker = nullptr;
-// QAction* HelpBrowser::macCmdEqualBlocker = nullptr;
+QAction* HelpBrowser::macCmdEqualBlocker = nullptr;
 #    endif
 
 HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -140,15 +140,25 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
 
 void HelpBrowser::onPageLoad() {
     mLoadProgressIndicator->stop();
-    // add these actions to weview's renderer, to capture shift+enter and possibly other swallowed shortcuts
+
     static_cast<OverridingAction*>(mActions[EvaluateRegion])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Evaluate])->addToWidget(mWebView->focusProxy());
+
+    // 이 오버라이딩 액션들이 focusProxy에 주입되면서 웹뷰 바닥에서부터 키를 낚아챕니다.
     static_cast<OverridingAction*>(mActions[ZoomIn])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ZoomOut])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ResetZoom])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Reload])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Back])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Forward])->addToWidget(mWebView->focusProxy());
+
+    // [맥OS 핵심 방어] focusProxy 내부에서 Zoom 액션들이 메인 메뉴바의 단축키를 이기도록
+    // WidgetWithChildrenShortcut 컨텍스트를 확실하게 재명시해 줍니다.
+#    ifdef Q_OS_MAC
+    mActions[ZoomIn]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mActions[ZoomOut]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mActions[ResetZoom]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+#    endif
 
 #    ifdef Q_OS_WIN
     if (!winCtrlRBlocker) {
@@ -157,25 +167,6 @@ void HelpBrowser::onPageLoad() {
         winCtrlRBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
     mWebView->focusProxy()->addAction(winCtrlRBlocker);
-#    endif
-
-#    ifdef Q_OS_MAC
-    if (!macCmdPlusBlocker) {
-        macCmdPlusBlocker = new OverridingAction(this);
-        // "Cmd++" 수신 시 주 편집창으로 가지 못하게 focusProxy 레벨에서 가로챔
-        macCmdPlusBlocker->setShortcut(QKeySequence("Cmd++"));
-        macCmdPlusBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-        // 가로챈 뒤, HelpBrowser의 줌인 기능을 수행하도록 연결
-        connect(macCmdPlusBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
-    }
-    if (!macCmdEqualBlocker) {
-        macCmdEqualBlocker = new OverridingAction(this);
-        macCmdEqualBlocker->setShortcut(QKeySequence("Cmd+="));
-        macCmdEqualBlocker->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-        connect(macCmdEqualBlocker, &QAction::triggered, this, &HelpBrowser::zoomIn);
-    }
-    mWebView->focusProxy()->addAction(macCmdPlusBlocker);
-    mWebView->focusProxy()->addAction(macCmdEqualBlocker);
 #    endif
 }
 
@@ -238,10 +229,10 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
 
 #    ifdef Q_OS_MAC
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Equal)); // Cmd + =
-    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Equal)); // Cmd + Shift + =  → +
+    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Equal)); // Cmd + Shift + =
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus)); // Cmd + + (keypad)
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Plus)); // Cmd + Shift + +
-    zoomInShortcuts.append(QKeySequence("Cmd++"));
+    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus));
 #    else
     zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal)); // Ctrl + =
     zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Equal)); // Ctrl + Shift + =  → +

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -143,7 +143,6 @@ void HelpBrowser::onPageLoad() {
     // add these actions to weview's renderer, to capture shift+enter and possibly other swallowed shortcuts
     static_cast<OverridingAction*>(mActions[EvaluateRegion])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Evaluate])->addToWidget(mWebView->focusProxy());
-
     static_cast<OverridingAction*>(mActions[ZoomIn])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ZoomOut])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ResetZoom])->addToWidget(mWebView->focusProxy());

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -146,9 +146,9 @@ void HelpBrowser::onPageLoad() {
     static_cast<OverridingAction*>(mActions[Back])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Forward])->addToWidget(mWebView->focusProxy());
 
-    mActions[ZoomIn]->setShortcutContext(Qt::WindowShortcut);
-    mActions[ZoomOut]->setShortcutContext(Qt::WindowShortcut);
-    mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
+    // mActions[ZoomIn]->setShortcutContext(Qt::WindowShortcut);
+    // mActions[ZoomOut]->setShortcutContext(Qt::WindowShortcut);
+    // mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
 
 #    ifdef Q_OS_WIN
     if (!winCtrlRBlocker) {
@@ -222,7 +222,6 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Equal)); // Cmd + Shift + =  → +
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus)); // Cmd + + (keypad)
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Plus)); // Cmd + Shift + +
-    zoomInShortcuts.append(QKeySequence("Meta++"));
     zoomInShortcuts.append(QKeySequence("Cmd++"));
 #    else
     zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal)); // Ctrl + =
@@ -235,9 +234,9 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
     mActions[ZoomOut]->setShortcut(settings->shortcut("editor-shrink-font"));
     mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
 
-    mActions[ZoomIn]->setShortcutContext(Qt::WindowShortcut);
-    mActions[ZoomOut]->setShortcutContext(Qt::WindowShortcut);
-    mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
+    // mActions[ZoomIn]->setShortcutContext(Qt::WindowShortcut);
+    // mActions[ZoomOut]->setShortcutContext(Qt::WindowShortcut);
+    // mActions[ResetZoom]->setShortcutContext(Qt::WindowShortcut);
 
     QList<QKeySequence> evalShortcuts;
     evalShortcuts.append(settings->shortcut("editor-eval-line"));

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -140,7 +140,7 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
 
 void HelpBrowser::onPageLoad() {
     mLoadProgressIndicator->stop();
-
+    // add these actions to weview's renderer, to capture shift+enter and possibly other swallowed shortcuts
     static_cast<OverridingAction*>(mActions[EvaluateRegion])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Evaluate])->addToWidget(mWebView->focusProxy());
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -143,6 +143,7 @@ void HelpBrowser::onPageLoad() {
     // add these actions to weview's renderer, to capture shift+enter and possibly other swallowed shortcuts
     static_cast<OverridingAction*>(mActions[EvaluateRegion])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[Evaluate])->addToWidget(mWebView->focusProxy());
+
     static_cast<OverridingAction*>(mActions[ZoomIn])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ZoomOut])->addToWidget(mWebView->focusProxy());
     static_cast<OverridingAction*>(mActions[ResetZoom])->addToWidget(mWebView->focusProxy());

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -229,15 +229,10 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
 
 #    ifdef Q_OS_MAC
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Equal)); // Cmd + =
-    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Equal)); // Cmd + Shift + =
     zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus)); // Cmd + + (keypad)
-    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Plus)); // Cmd + Shift + +
-    zoomInShortcuts.append(QKeySequence(Qt::META | Qt::Key_Plus));
 #    else
     zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal)); // Ctrl + =
-    zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Equal)); // Ctrl + Shift + =  → +
     zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Plus)); // Ctrl + + (keypad)
-    zoomInShortcuts.append(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Plus)); // Ctrl + Shift + +
 #    endif
 
     mActions[ZoomIn]->setShortcuts(zoomInShortcuts);

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -152,6 +152,12 @@ private:
     QAction* mActions[ActionCount];
 
     int mServerPort = 0; // if 0, server is not running
+
+#ifdef Q_OS_WIN
+    // Blocks the default Ctrl+R behavior on Windows, which would otherwise
+    // trigger an unwanted refresh action in the embedded browser widget.
+    static QAction* winCtrlRBlocker;
+#endif
 };
 
 class HelpBrowserFindBox : public QLineEdit {

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -154,9 +154,16 @@ private:
     int mServerPort = 0; // if 0, server is not running
 
 #ifdef Q_OS_WIN
-    // Blocks the default Ctrl+R behavior on Windows, which would otherwise
+    // Blocks the default `Ctrl + R` behavior on Windows, which would otherwise
     // trigger an unwanted refresh action in the embedded browser widget.
     static QAction* winCtrlRBlocker;
+#endif
+
+#ifdef Q_OS_MAC
+    // Blocks the default `Cmd + +` behavior on macOS, which would otherwise
+    // trigger an unwanted font‑size increase in the SC‑IDE code editor.
+    static QAction* macCmdPlusBlocker;
+    // static QAction* macCmdEqualBlocker;
 #endif
 };
 

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -163,7 +163,7 @@ private:
     // Blocks the default `Cmd + +` behavior on macOS, which would otherwise
     // trigger an unwanted font‑size increase in the SC‑IDE code editor.
     static QAction* macCmdPlusBlocker;
-    // static QAction* macCmdEqualBlocker;
+    static QAction* macCmdEqualBlocker;
 #endif
 };
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Fix shortcut propagation issues in HelpBrowser.
- Added platform-specific overriding actions (`macCmdPlusBlocker` and `macCmdEqualBlocker`) using `Qt::WidgetWithChildrenShortcut` to properly intercept and process zoom shortcuts locally, preventing them from propagating to the main window. However, they do not work currently, so the relevant code has been left for future work.
- Resolved an issue with `Cmd/Ctrl + Shift + =` by cleanly removing the unsupported mapping.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
